### PR TITLE
Lump のストレージ使用量を問い合わせられるようにする

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = {repository = "frugalos/cannyls_rpc"}
 [dependencies]
 atomic_immut = "0.1"
 bytecodec = "0.4"
-cannyls = "0.9"
+cannyls = "0.9.4"
 factory = "0.1"
 fibers = "0.1"
 fibers_rpc = "0.2"
@@ -27,6 +27,3 @@ trackable = "0.2"
 
 [dev-dependencies]
 tempdir = "0.3"
-
-[patch.crates-io]
-cannyls = { path = "../cannyls" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cannyls_rpc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The FrugalOS Developers"]
 description = "RPC library for operating cannyls's devices from remote nodes"
 homepage = "https://github.com/frugalos/cannyls_rpc"
@@ -27,3 +27,6 @@ trackable = "0.2"
 
 [dev-dependencies]
 tempdir = "0.3"
+
+[patch.crates-io]
+cannyls = { path = "../cannyls" }

--- a/src/protobuf.rs
+++ b/src/protobuf.rs
@@ -3,7 +3,7 @@
 //! メッセージ定義は[cannyls_rpc.proto]を参照のこと.
 //!
 //! [cannyls_rpc.proto]: https://github.com/frugalos/cannyls_rpc/blob/master/protobuf/cannyls_rpc.proto
-#![cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::type_complexity))]
 use bytecodec::bytes::BytesDecoder as BytecodecBytesDecoder;
 use bytecodec::combinator::{Peekable, PreEncode};
 use bytecodec::{self, ByteCount, Decode, Encode, Eos, ErrorKind, Result, SizedEncode};

--- a/src/protobuf.rs
+++ b/src/protobuf.rs
@@ -23,7 +23,8 @@ use protobuf_codec::field::{
 use protobuf_codec::message::{MessageDecode, MessageDecoder, MessageEncode, MessageEncoder};
 use protobuf_codec::scalar::{
     BoolDecoder, BoolEncoder, BytesDecoder, BytesEncoder, CustomBytesDecoder, Fixed64Decoder,
-    Fixed64Encoder, StringDecoder, StringEncoder, Uint32Decoder, Uint32Encoder,
+    Fixed64Encoder, StringDecoder, StringEncoder, Uint32Decoder, Uint32Encoder, Uint64Decoder,
+    Uint64Encoder,
 };
 use protobuf_codec::wellknown::google::protobuf::{StdDurationDecoder, StdDurationEncoder};
 use protobuf_codec::wellknown::protobuf_codec::protobuf::trackable;
@@ -163,8 +164,8 @@ impl_sized_message_encode!(DeadlineEncoder, Deadline, |item: Self::Item| match i
 pub struct StorageUsageDecoder {
     inner: MessageDecoder<
         Fields<(
-            MaybeDefault<FieldDecoder<F1, Uint32Decoder>>,
-            MaybeDefault<FieldDecoder<F2, Uint32Decoder>>,
+            MaybeDefault<FieldDecoder<F1, Uint64Decoder>>,
+            MaybeDefault<FieldDecoder<F2, Uint64Decoder>>,
         )>,
     >,
 }
@@ -184,8 +185,8 @@ impl_message_decode!(StorageUsageDecoder, StorageUsage, |(kind, usage)| Ok(
 pub struct StorageUsageEncoder {
     inner: MessageEncoder<
         Fields<(
-            FieldEncoder<F1, Uint32Encoder>,
-            MaybeDefault<FieldEncoder<F2, Uint32Encoder>>,
+            FieldEncoder<F1, Uint64Encoder>,
+            MaybeDefault<FieldEncoder<F2, Uint64Encoder>>,
         )>,
     >,
 }

--- a/src/protobuf.rs
+++ b/src/protobuf.rs
@@ -12,6 +12,7 @@ use cannyls::block::BlockSize;
 use cannyls::deadline::Deadline;
 use cannyls::device::DeviceHandle;
 use cannyls::lump::{LumpData, LumpHeader, LumpId};
+use cannyls::storage::StorageUsage;
 use factory::Factory;
 use protobuf_codec::field::branch::Branch2;
 use protobuf_codec::field::num::{F1, F2, F3, F4};
@@ -28,9 +29,10 @@ use protobuf_codec::wellknown::google::protobuf::{StdDurationDecoder, StdDuratio
 use protobuf_codec::wellknown::protobuf_codec::protobuf::trackable;
 use protobuf_codec::wire::Tag;
 use std;
+use std::ops::Range;
 use trackable::error::{ErrorKindExt, TrackableError};
 
-use rpc::{DeviceRequest, LumpRequest, PutLumpRequest, RequestOptions};
+use rpc::{DeviceRequest, LumpRequest, PutLumpRequest, RequestOptions, UsageRangeRequest};
 use {DeviceId, DeviceRegistryHandle};
 
 macro_rules! impl_message_decode {
@@ -166,21 +168,20 @@ pub struct RequestOptionsDecoder {
         )>,
     >,
 }
-impl_message_decode!(
-    RequestOptionsDecoder,
-    RequestOptions,
-    |(deadline, queue_size_limit)| {
-        let max_queue_len = if queue_size_limit == 0 {
-            None
-        } else {
-            Some(queue_size_limit as usize - 1)
-        };
-        Ok(RequestOptions {
-            deadline,
-            max_queue_len,
-        })
-    }
-);
+impl_message_decode!(RequestOptionsDecoder, RequestOptions, |(
+    deadline,
+    queue_size_limit,
+)| {
+    let max_queue_len = if queue_size_limit == 0 {
+        None
+    } else {
+        Some(queue_size_limit as usize - 1)
+    };
+    Ok(RequestOptions {
+        deadline,
+        max_queue_len,
+    })
+});
 
 #[derive(Debug, Default)]
 pub struct RequestOptionsEncoder {
@@ -206,15 +207,15 @@ pub struct LumpRequestDecoder {
         )>,
     >,
 }
-impl_message_decode!(
-    LumpRequestDecoder,
-    LumpRequest,
-    |(device_id, lump_id, options)| Ok(LumpRequest {
-        device_id: DeviceId::new(device_id),
-        lump_id,
-        options,
-    })
-);
+impl_message_decode!(LumpRequestDecoder, LumpRequest, |(
+    device_id,
+    lump_id,
+    options,
+)| Ok(LumpRequest {
+    device_id: DeviceId::new(device_id),
+    lump_id,
+    options,
+}));
 
 #[derive(Debug, Default)]
 pub struct LumpRequestEncoder {
@@ -441,7 +442,8 @@ impl Decode for LumpDataDecoder {
                 track!(device.allocate_lump_data(data_size))
             } else {
                 track!(LumpData::new(vec![0; data_size]))
-            }.map_err(|e| ErrorKind::InvalidInput.takes_over(e))?;
+            }
+            .map_err(|e| ErrorKind::InvalidInput.takes_over(e))?;
             self.bytes = BytecodecBytesDecoder::new(data);
         }
         track!(self.bytes.decode(buf, eos))
@@ -633,14 +635,13 @@ pub struct DeviceRequestDecoder {
         )>,
     >,
 }
-impl_message_decode!(
-    DeviceRequestDecoder,
-    DeviceRequest,
-    |(device_id, options)| Ok(DeviceRequest {
-        device_id: DeviceId::new(device_id),
-        options,
-    })
-);
+impl_message_decode!(DeviceRequestDecoder, DeviceRequest, |(
+    device_id,
+    options,
+)| Ok(DeviceRequest {
+    device_id: DeviceId::new(device_id),
+    options,
+}));
 
 #[derive(Debug, Default)]
 pub struct DeviceRequestEncoder {
@@ -657,6 +658,52 @@ impl_sized_message_encode!(DeviceRequestEncoder, DeviceRequest, |item: Self::Ite
 ));
 
 #[derive(Debug, Default)]
+pub struct UsageRangeRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, StringDecoder>>,
+            MessageFieldDecoder<F2, LumpIdDecoder>,
+            MessageFieldDecoder<F3, LumpIdDecoder>,
+            MessageFieldDecoder<F4, RequestOptionsDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(UsageRangeRequestDecoder, UsageRangeRequest, |(
+    device_id,
+    start,
+    end,
+    options,
+)| Ok(
+    UsageRangeRequest {
+        device_id: DeviceId::new(device_id),
+        range: Range { start, end },
+        options,
+    }
+));
+
+#[derive(Debug, Default)]
+pub struct UsageRangeRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            MaybeDefault<FieldEncoder<F1, StringEncoder>>,
+            MessageFieldEncoder<F2, LumpIdEncoder>,
+            MessageFieldEncoder<F3, LumpIdEncoder>,
+            MessageFieldEncoder<F4, RequestOptionsEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    UsageRangeRequestEncoder,
+    UsageRangeRequest,
+    |item: Self::Item| (
+        item.device_id.into_string(),
+        item.range.start,
+        item.range.end,
+        item.options,
+    )
+);
+
+#[derive(Debug, Default)]
 pub struct ListLumpResponseDecoder {
     inner: MessageDecoder<
         Fields<(
@@ -665,15 +712,16 @@ pub struct ListLumpResponseDecoder {
         )>,
     >,
 }
-impl_message_decode!(
-    ListLumpResponseDecoder,
-    cannyls::Result<Vec<LumpId>>,
-    |(ids, error)| if let Some(error) = error {
-        Ok(Err(error))
-    } else {
-        Ok(Ok(ids))
-    }
-);
+impl_message_decode!(ListLumpResponseDecoder, cannyls::Result<Vec<LumpId>>, |(
+    ids,
+    error,
+)| if let Some(error) =
+    error
+{
+    Ok(Err(error))
+} else {
+    Ok(Ok(ids))
+});
 
 #[derive(Debug, Default)]
 pub struct ListLumpResponseEncoder {
@@ -690,6 +738,43 @@ impl_message_encode!(
     |item: Self::Item| match item {
         Err(e) => (Vec::new(), Some(e)),
         Ok(ids) => (ids, None),
+    }
+);
+
+#[derive(Debug, Default)]
+pub struct UsageRangeResponseDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, Uint32Decoder>>,
+            Optional<MessageFieldDecoder<F2, ErrorDecoder>>,
+        )>,
+    >,
+}
+impl_message_decode!(
+    UsageRangeResponseDecoder,
+    cannyls::Result<StorageUsage>,
+    |(usage, error)| if let Some(error) = error {
+        Ok(Err(error))
+    } else {
+        Ok(Ok(StorageUsage::new(usage)))
+    }
+);
+
+#[derive(Debug, Default)]
+pub struct UsageRangeResponseEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            MaybeDefault<FieldEncoder<F1, Uint32Encoder>>,
+            Optional<MessageFieldEncoder<F2, ErrorEncoder>>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    UsageRangeResponseEncoder,
+    cannyls::Result<StorageUsage>,
+    |item: Self::Item| match item {
+        Err(e) => (Default::default(), Some(e)),
+        Ok(usage) => (usage.as_bytes(), None),
     }
 );
 
@@ -740,59 +825,69 @@ mod tests {
             let mut encoder: $encoder = Default::default();
             let mut decoder: $decoder = Default::default();
 
-            let bytes = track_try_unwrap!(encoder.encode_into_bytes($value));
+            let bytes = track_try_unwrap!(encoder.encode_into_bytes($value()));
             let decoded = track_try_unwrap!(track!(decoder.decode_from_bytes(&bytes); bytes));
-            assert_eq!(decoded, $value);
+            assert_eq!(decoded, $value());
         };
     }
 
     #[test]
     fn lump_id_encdec_works() {
-        assert_encdec!(LumpIdEncoder, LumpIdDecoder, LumpId::new(0));
-        assert_encdec!(LumpIdEncoder, LumpIdDecoder, LumpId::new((123 << 64) | 345));
+        assert_encdec!(LumpIdEncoder, LumpIdDecoder, || LumpId::new(0));
+        assert_encdec!(LumpIdEncoder, LumpIdDecoder, || LumpId::new(
+            (123 << 64) | 345
+        ));
     }
 
     #[test]
     fn deadline_encdec_works() {
-        assert_encdec!(DeadlineEncoder, DeadlineDecoder, Deadline::Immediate);
-        assert_encdec!(DeadlineEncoder, DeadlineDecoder, Deadline::Infinity);
-        assert_encdec!(
-            DeadlineEncoder,
-            DeadlineDecoder,
-            Deadline::Within(Duration::from_secs(0))
-        );
-        assert_encdec!(
-            DeadlineEncoder,
-            DeadlineDecoder,
-            Deadline::Within(Duration::from_millis(123))
-        );
+        assert_encdec!(DeadlineEncoder, DeadlineDecoder, || Deadline::Immediate);
+        assert_encdec!(DeadlineEncoder, DeadlineDecoder, || Deadline::Infinity);
+        assert_encdec!(DeadlineEncoder, DeadlineDecoder, || Deadline::Within(
+            Duration::from_secs(0)
+        ));
+        assert_encdec!(DeadlineEncoder, DeadlineDecoder, || Deadline::Within(
+            Duration::from_millis(123)
+        ));
     }
 
     #[test]
     fn request_options_encdec_works() {
-        assert_encdec!(
-            RequestOptionsEncoder,
-            RequestOptionsDecoder,
+        assert_encdec!(RequestOptionsEncoder, RequestOptionsDecoder, || {
             RequestOptions {
                 deadline: Deadline::Immediate,
-                max_queue_len: None
+                max_queue_len: None,
             }
-        );
-        assert_encdec!(
-            RequestOptionsEncoder,
-            RequestOptionsDecoder,
+        });
+        assert_encdec!(RequestOptionsEncoder, RequestOptionsDecoder, || {
             RequestOptions {
                 deadline: Deadline::Infinity,
-                max_queue_len: Some(0)
+                max_queue_len: Some(0),
             }
-        );
-        assert_encdec!(
-            RequestOptionsEncoder,
-            RequestOptionsDecoder,
+        });
+        assert_encdec!(RequestOptionsEncoder, RequestOptionsDecoder, || {
             RequestOptions {
                 deadline: Deadline::Infinity,
-                max_queue_len: Some(123)
+                max_queue_len: Some(123),
             }
-        );
+        });
+    }
+
+    #[test]
+    fn usage_range_request_encdec_works() {
+        let request = UsageRangeRequest {
+            device_id: DeviceId::new("device"),
+            range: Range {
+                start: LumpId::new(1),
+                end: LumpId::new(3),
+            },
+            options: RequestOptions {
+                deadline: Deadline::Infinity,
+                max_queue_len: Some(123),
+            },
+        };
+        assert_encdec!(UsageRangeRequestEncoder, UsageRangeRequestDecoder, || {
+            request.clone()
+        });
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,8 +1,10 @@
 use cannyls::deadline::Deadline;
 use cannyls::device::{self, DeviceHandle};
 use cannyls::lump::{LumpData, LumpHeader, LumpId};
+use cannyls::storage::StorageUsage;
 use cannyls::Result;
 use fibers_rpc::{Call, ProcedureId};
+use std::ops::Range;
 
 use device::DeviceId;
 use protobuf::{
@@ -10,7 +12,8 @@ use protobuf::{
     GetLumpResponseDecoder, GetLumpResponseEncoder, HeadLumpResponseDecoder,
     HeadLumpResponseEncoder, ListLumpResponseDecoder, ListLumpResponseEncoder, LumpRequestDecoder,
     LumpRequestEncoder, PutLumpRequestDecoder, PutLumpRequestEncoder, PutLumpResponseDecoder,
-    PutLumpResponseEncoder,
+    PutLumpResponseEncoder, UsageRangeRequestDecoder, UsageRangeRequestEncoder,
+    UsageRangeResponseDecoder, UsageRangeResponseEncoder,
 };
 
 const NS_CANNYLS: u32 = 0x0001_0000; // cannyls用のRPCの名前空間(ID範囲)
@@ -90,6 +93,21 @@ impl Call for ListLumpRpc {
     type ResEncoder = ListLumpResponseEncoder;
 }
 
+#[derive(Debug)]
+pub struct UsageRangeRpc;
+impl Call for UsageRangeRpc {
+    const ID: ProcedureId = ProcedureId(NS_CANNYLS | 0x0006);
+    const NAME: &'static str = "cannyls.lump.usage_range";
+
+    type Req = UsageRangeRequest;
+    type ReqDecoder = UsageRangeRequestDecoder;
+    type ReqEncoder = UsageRangeRequestEncoder;
+
+    type Res = Result<StorageUsage>;
+    type ResDecoder = UsageRangeResponseDecoder;
+    type ResEncoder = UsageRangeResponseEncoder;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RequestOptions {
     pub deadline: Deadline,
@@ -124,5 +142,12 @@ pub struct PutLumpRequest {
     pub device_id: DeviceId,
     pub lump_id: LumpId,
     pub lump_data: LumpData,
+    pub options: RequestOptions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UsageRangeRequest {
+    pub device_id: DeviceId,
+    pub range: Range<LumpId>,
     pub options: RequestOptions,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,6 +39,7 @@ impl Server {
         );
         builder.add_call_handler::<rpc::DeleteLumpRpc, _>(clone());
         builder.add_call_handler::<rpc::ListLumpRpc, _>(clone());
+        builder.add_call_handler::<rpc::UsageRangeRpc, _>(clone());
     }
 }
 impl HandleCall<rpc::GetLumpRpc> for Server {
@@ -82,6 +83,17 @@ impl HandleCall<rpc::ListLumpRpc> for Server {
     fn handle_call(&self, request: rpc::DeviceRequest) -> Reply<rpc::ListLumpRpc> {
         let device = rpc_try!(self.registry.get_device(&request.device_id));
         let future = request.options.with(&device).list().then(Ok);
+        Reply::future(future)
+    }
+}
+impl HandleCall<rpc::UsageRangeRpc> for Server {
+    fn handle_call(&self, request: rpc::UsageRangeRequest) -> Reply<rpc::UsageRangeRpc> {
+        let device = rpc_try!(self.registry.get_device(&request.device_id));
+        let future = request
+            .options
+            .with(&device)
+            .usage_range(request.range)
+            .then(Ok);
         Reply::future(future)
     }
 }


### PR DESCRIPTION
https://github.com/frugalos/cannyls/pull/42 で追加予定に対応する。

- ストレージ使用量を問い合わせるリクエストの RPC 定義 ( UsageRangeRpc ) と、その rpc server の handler を追加
- UsageRangeRequest/Response 用の protobuf Encoder/Decoder 実装を追加
