### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cannyls_rpc"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["The FrugalOS Developers"]
 description = "RPC library for operating cannyls's devices from remote nodes"
 homepage = "https://github.com/frugalos/cannyls_rpc"


### PR DESCRIPTION
https://github.com/frugalos/cannyls_rpc/pull/6 を含む。