### PR TITLE
Add stop_device, is_device_running to DeviceRegistry

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -105,6 +105,17 @@ impl DeviceRegistry {
         }
     }
 
+    /// デバイスが動いているかどうかを返す。
+    pub fn is_device_running(&mut self, device_id: &DeviceId) -> bool {
+        info!(self.logger, "Checking if device {:?} is running", device_id);
+        if let Some(state) = self.devices.get(device_id) {
+            !state.terminated
+        } else {
+            info!(self.logger, "Invalid device ID: {:?}", device_id);
+            false
+        }
+    }
+
     fn handle_command(&mut self, command: Command) {
         match command {
             Command::PutDevice(id, device) => self.handle_put_device(&id, device),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -85,6 +85,26 @@ impl DeviceRegistry {
         self.being_stopped = true;
     }
 
+    /// デバイスを止める。
+    /// 対象とするデバイスが見つかった場合は true を、見つからなかった場合は false を返す。
+    pub fn stop_device(&mut self, device_id: &DeviceId) -> bool {
+        info!(self.logger, "Stopping device: {:?}", device_id);
+        if let Some(state) = self.devices.get(device_id) {
+            if state.terminated {
+                info!(
+                    self.logger,
+                    "stop_device: Device {:?} has already been terminated", device_id
+                );
+            } else {
+                state.device.stop(Deadline::Immediate);
+            }
+            true
+        } else {
+            info!(self.logger, "Invalid device ID: {:?}", device_id);
+            false
+        }
+    }
+
     fn handle_command(&mut self, command: Command) {
         match command {
             Command::PutDevice(id, device) => self.handle_put_device(&id, device),


### PR DESCRIPTION
デバイス停止・デバイスの情報取得リクエストの処理の流れ:
```
config_server

|
V

daemon

|
V

service

 - Service::stop_device, Service::get_device_state

|
V

frugalos_segment/service.rs
Service
stop_device, get_device_state

|
V

cannyls_rpc/DeviceRegistry
stop_device, is_device_running

|
V

cannyls::device::Device::stop (no need of change)
```